### PR TITLE
Allow spatialite-enabled database connections.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
 Suggests:
     testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    RSQLite
 LazyData: TRUE
 RoxygenNote: 5.0.1
 VignetteBuilder: knitr

--- a/man/get_postgis_query.Rd
+++ b/man/get_postgis_query.Rd
@@ -5,17 +5,21 @@
 \title{Send SELECT query and parse geometry, hstore columns}
 \usage{
 get_postgis_query(conn, statement, geom_name = NA_character_,
-  hstore_name = NA_character_)
+  hstore_name = NA_character_, mod_spatialite = "mod_spatialite")
 }
 \arguments{
-\item{conn}{A \code{\link[RPostgreSQL]{PostgreSQLConnection-class}} object,
-such as the output of \code{\link[DBI]{dbConnect}}.}
+\item{conn}{A \code{\link[RPostgreSQL]{PostgreSQLConnection-class}} or
+\code{\link[RSQLite]{SQLiteConnection-class}} object,
+  such as the output of \code{\link[DBI]{dbConnect}}.}
 
 \item{statement}{Character string for a SQL SELECT query.}
 
 \item{geom_name}{Name of the geometry column (\code{NA} if none).}
 
 \item{hstore_name}{Name of the hstore column (\code{NA} if none).}
+
+\item{mod_spatialite}{Shared library containing the spatialite extension if
+conn is a SQLiteConnection.}
 }
 \value{
 Either a data frame (if \code{geom_name = NA}) or a


### PR DESCRIPTION
I have been working with some Spatialite databases recently and realised that many of the same spatial functions, including the ones used in this package, also apply to Spatialite-enabled databases so the same code can support both PostgreSQL/PostGIS and Spatialite. This PR adds the necessary steps needed to enable the Spatialite extension using an RSQLiteConnection after which the get_postgis_query function works as normal.

One caveat, I have only tested this on Linux and these functions require the mod_spatialite library to be installed on the computer.